### PR TITLE
Upgrade to Elasticsearch 2.x

### DIFF
--- a/app/elastic_record/elastic_query.rb
+++ b/app/elastic_record/elastic_query.rb
@@ -39,7 +39,7 @@ class ElasticQuery
         end
         {
           range: {
-            matcher[1] => {
+            ElasticQuery.field_name(matcher[1]) => {
               gte: operand
             }
           }
@@ -160,9 +160,9 @@ class ElasticQuery
         { match_all: {} }
       when 1
         k, v = query_options.first
-        { match: {k.to_s => {query: v}}}
+        { match: {ElasticQuery.field_name(k) => {query: v}}}
       else
-        { bool: { must: (query_options.map { |k, v| { match: { k.to_s => v.to_single } } }) } }
+        { bool: { must: (query_options.map { |k, v| { match: { ElasticQuery.field_name(k) => v.to_single } } }) } }
       end
 
       body = { query: query }
@@ -183,7 +183,7 @@ class ElasticQuery
       unless @order.empty?
         body[:sort] = @order.map do |sort|
           field, direction = sort.split(' ')
-          {field => direction}
+          {ElasticQuery.field_name(field) => direction}
         end.flatten
       end
 
@@ -206,4 +206,13 @@ class ElasticQuery
     new_record
   end
 
+  def self.field_name(name)
+    name = name.to_s
+    case name
+    when "created_at", "updated_at"
+      name
+    else
+      "properties.#{name}"
+    end
+  end
 end

--- a/app/models/elastic_search_selectors/grouped.rb
+++ b/app/models/elastic_search_selectors/grouped.rb
@@ -13,7 +13,7 @@ class ElasticSearchSelectors::Grouped < ElasticSearchSelector
       aggregations: {
         "#{group_by}_aggregation" => {
           terms: {
-            field: group_by
+            field: ElasticQuery.field_name(group_by)
           }
         }
       }

--- a/app/models/elastic_search_selectors/grouped_by_and_aggregated.rb
+++ b/app/models/elastic_search_selectors/grouped_by_and_aggregated.rb
@@ -15,12 +15,12 @@ class ElasticSearchSelectors::GroupedByAndAggregated < ElasticSearchSelector
       aggregations: {
         "#{group_by}_aggregation" => {
           terms: {
-            field: group_by,
+            field: ElasticQuery.field_name(group_by),
           },
           aggregations: {
             "#{field}_#{aggregate}" => {
               es_aggregation(aggregate) => {
-                field: field
+                field: ElasticQuery.field_name(field)
               }
             }
           }

--- a/app/models/local_search.rb
+++ b/app/models/local_search.rb
@@ -94,13 +94,13 @@ class LocalSearch
         values = Array(restriction[:value]).map &:to_s
 
         if values.count == 1
-          musts << { match: { restriction[:field] => values.first } }
+          musts << { match: { ElasticQuery.field_name(restriction[:field]) => values.first } }
         else
           shoulds = []
           match_any_value = { bool: { should: shoulds, minimum_should_match: 1 } }
           musts << match_any_value
           values.each do |v|
-            shoulds << { match: { restriction[:field] => v } }
+            shoulds << { match: { ElasticQuery.field_name(restriction[:field]) => v } }
           end
         end
       end


### PR DESCRIPTION
Since Elasticsearch 2.x fields cannot be referenced by short name: https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_mapping_changes.html#_fields_cannot_be_referenced_by_short_name

So for example in a document like this

```json
{
  "properties": {
    "age": 10
  }
}
```

we **must** use "properties.age" in queries.

We do this for fields that are not named "created_at" and "updated_at", I don't know if other fields need to be ignored as well. I also don't know why the properties are inside another "properties" and not just outside it, would probably be easier to upgrade and to deal with...

/cc @bcardiff @nekron 